### PR TITLE
FLUID-5581

### DIFF
--- a/src/documents/tutorial-gettingStartedWithInfusion/EventedComponents.md
+++ b/src/documents/tutorial-gettingStartedWithInfusion/EventedComponents.md
@@ -152,7 +152,7 @@ fluid.defaults("tutorials.currencyConverter", {
     },
     modelListeners: {
         convertedAmount: {
-            funcName: "{that}.events.conversionUpdated.fire",
+            listener: "{that}.events.conversionUpdated.fire",
             args: "{change}.value"
         }
     }


### PR DESCRIPTION
Restoring property from funcName to func. This is because the reference is a pointer to an IoC resolved method rather than to the name of a function.

http://issues.fluidproject.org/browse/FLUID-5581
