### PR TITLE
FLUID-5631: Fixing some formatting things.

### DIFF
--- a/src/documents/Builder.md
+++ b/src/documents/Builder.md
@@ -16,6 +16,7 @@ var builder = fluid.prefs.builder(<options>);
 <table>
 <tr><td><code>options</code></td><td>(Object) The configuration options for the builder. See <a href="#options">Options</a> below for more information.</td></tr>
 </table>
+
 where `options` is a JavaScript object containing information configuring your builder.
 
 ### Return Value ###

--- a/src/documents/ComponentGrades.md
+++ b/src/documents/ComponentGrades.md
@@ -23,14 +23,11 @@ The Infusion Framework already contains several predefined component grades that
             <td>autoinit</td>
             <td></td>
             <td>
-                <p>
-                    A special directive grade that instructs the framework to automatically construct a globally named creator function (with the same name as the grade) responsible for the construction of the component. NOTE: for the Infusion 2.0 release this grade will become redundant as it will be the default for every grade
-                </p>
-                <p>
-                    <em>
-                        <strong>NOTE:</strong> for the Infusion 2.0 release this grade will become redundant as it will be the default for every grade
-                    </em>
-                </p>
+                A special directive grade that instructs the framework to automatically construct a globally named creator function (with the same name as the grade) responsible for the construction of the component. NOTE: for the Infusion 2.0 release this grade will become redundant as it will be the default for every grade
+                <br/>
+                <em>
+                    <strong>NOTE:</strong> for the Infusion 2.0 release this grade will become redundant as it will be the default for every grade
+                </em>
             </td>
         </tr>
         <tr>

--- a/src/documents/UnderstandingInfusionComponents.md
+++ b/src/documents/UnderstandingInfusionComponents.md
@@ -48,8 +48,7 @@ Most will have:
 * a **creator function**
   * the function that implementors invoke, which returns the component object itself
 * configuration options
-  * various values that control the operation of the component, which can be overridden by implementors
-        to customize the component
+  * various values that control the operation of the component, which can be overridden by implementors to customize the component
 * public functions
 
 Depending on what the component is for, some will include infrastructure to support


### PR DESCRIPTION
Specifically:
• Understanding  Infusion Components - section What Does a Component Look Like - there was  a section of text "to customize the component" that is styled like a  code block
• Component Grades first table - Description text in first row was much bigger than all the rest
• Builder page: formatting of "Return Value" under Parameters wasn't working 