### PR TITLE
FLUID-5619: TOC fixes, active category styling

### DIFF
--- a/site-structure.json
+++ b/site-structure.json
@@ -1,6 +1,7 @@
 [
     {
         "category": "Infusion",
+        "categoryHref": "/index.html",
         "sections":
         [
             {
@@ -110,6 +111,7 @@
     },
     {
         "category": "Tutorials",
+        "categoryHref": "/index-tutorials.html",
         "sections":
         [
             {
@@ -164,6 +166,7 @@
     },
     {
         "category": "API",
+        "categoryHref": "/index-api.html",
         "sections":
         [
             {

--- a/src/layouts/default.html.handlebars
+++ b/src/layouts/default.html.handlebars
@@ -49,9 +49,14 @@
                 </div>
 
                 <nav class="small-12 medium-9 column">
-                    <a href="{{{relativeUrl '/index.html' document.url}}}" title="Infusion">Infusion</a>
-                    <a href="{{{relativeUrl '/index-tutorials.html' document.url}}}" title="Tutorials">Tutorials</a>
-                    <a href="{{{relativeUrl '/index-api.html' document.url}}}" title="A P I">API</a>
+                    {{! Highlight the (active) category the document belongs to. }}
+                    {{#each siteStructure}}
+                        {{#ifEqual category ../document.category}}
+                            <a href="{{{relativeUrl categoryHref ../../document.url}}}" title="{{category}}" class="infusion-docs-category-active">{{category}}</a>
+                        {{else}}
+                            <a href="{{{relativeUrl categoryHref ../../document.url}}}" title="{{category}}">{{category}}</a>
+                        {{/ifEqual}}
+                    {{/each}}
                 </nav>
             </header>
 

--- a/src/static/css/infusion-docs.css
+++ b/src/static/css/infusion-docs.css
@@ -206,6 +206,10 @@ a:focus {
     border-top: 0.1rem solid #efefef;
 }
 
+.infusion-docs-TOC li:first-child {
+    border-top: none;
+}
+
 .infusion-docs-category {
     font-weight: bold;
     margin: 1.5rem 0 1rem 0;

--- a/src/static/css/infusion-docs.css
+++ b/src/static/css/infusion-docs.css
@@ -157,20 +157,24 @@ a:focus {
     color: #ffb200;
 }
 
-.infusion-docs-container .infusion-docs-header nav {
+.infusion-docs-header nav {
     margin-top: 1rem;
 }
-.infusion-docs-container .infusion-docs-header nav a {
+.infusion-docs-header nav a {
     color: #FFFFFF;
 }
 
-.infusion-docs-container .infusion-docs-header a:hover {
+.infusion-docs-header a:hover {
     color: #008cba;
     background: #f2f2f2;
 }
 
 .infusion-docs-header a:hover:before {
     color: #008cba;
+}
+
+.infusion-docs-category-active {
+    border-bottom: 0.2rem solid #ffb200;
 }
 
 .infusion-docs-container .infusion-docs-header .infusion-docs-linkDOCS {

--- a/src/static/css/infusion-docs.css
+++ b/src/static/css/infusion-docs.css
@@ -64,6 +64,7 @@ td {
 }
 
 .fl-prefsEditor-buttons button:focus,
+.infusion-docs-TOC li a:focus .infusion-docs-TOC-pageName,
 a:focus {
     outline: solid 0.2rem #008cba;
 }
@@ -196,7 +197,8 @@ a:focus {
 }
 
 .infusion-docs-TOC li {
-    margin-bottom: 1rem;
+    padding: 0.6rem 0;
+    border-top: 0.1rem solid #efefef;
 }
 
 .infusion-docs-category {
@@ -210,10 +212,15 @@ a:focus {
     display: block;
 }
 
+.infusion-docs-TOC li a:focus {
+    outline: none;
+}
+
 .infusion-docs-TOC li .infusion-docs-TOC-pageName {
     /* By default give each item in the TOC an active page style. */
     border-left: solid 0.2rem #FFCB00;
     padding-left: 0.2rem;
+    display: block;
 }
 
 .infusion-docs-TOC li a .infusion-docs-TOC-pageName {
@@ -314,9 +321,12 @@ div.infusion-docs-note {
     padding-top: 2rem;
     color: #FFFFFF;
     font-family: "OpenSans", Arial, Helvetica;
-    font-size: 1.1rem;
     text-align: center;
     max-width: 100%;
+}
+
+.infusion-docs-footer p {
+    font-size: 0.8rem;
 }
 
 .infusion-docs-footer a {
@@ -373,21 +383,37 @@ div.infusion-docs-note {
 
 .fl-theme-bw a:focus,
 .fl-theme-bw .fl-prefsEditor-buttons button:focus,
+.fl-theme-bw a:focus .infusion-docs-TOC-pageName,
 .fl-theme-by a:focus,
 .fl-theme-by .fl-prefsEditor-buttons button:focus {
     outline: 0.2rem solid #000000 !important;
 }
 .fl-theme-wb a:focus,
+.fl-theme-wb a:focus .infusion-docs-TOC-pageName,
 .fl-theme-wb .fl-prefsEditor-buttons button:focus {
     outline: 0.2rem solid #ffffff !important;
 }
 .fl-theme-yb a:focus,
+.fl-theme-yb a:focus .infusion-docs-TOC-pageName,
 .fl-theme-yb .fl-prefsEditor-buttons button:focus {
     outline: 0.2rem solid #ffff00 !important;
 }
 .fl-theme-lgdg a:focus,
+.fl-theme-lgdg a:focus .infusion-docs-TOC-pageName,
 .fl-theme-lgdg .fl-prefsEditor-buttons button:focus {
     outline: 0.2rem solid #bdbdbb !important;
+}
+
+/*
+Focus style exception: don't have focus appear around the anchor.
+Instead have it appear around the enclosed
+*/
+.fl-theme-bw .infusion-docs-TOC li a:focus,
+.fl-theme-wb .infusion-docs-TOC li a:focus,
+.fl-theme-by .infusion-docs-TOC li a:focus,
+.fl-theme-yb .infusion-docs-TOC li a:focus,
+.fl-theme-lgdg .infusion-docs-TOC li a:focus {
+    outline:none !important;
 }
 
 .fl-theme-bw .infusion-docs-container a:hover,


### PR DESCRIPTION
- An underline now appears below the current active category in the header navigation.
- Added styling to ToC which gives better distinction between TOC items.
- Shrank Footer text to 0.8 rem.