### PR TITLE
FLUID-5781: Removed docpad from the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "https://github.com/fluid-project/infusion-docs",
   "dependencies": {
     "URIjs": "^1.14.1",
-    "docpad": "~6.69.1",
     "docpad-plugin-ghpages": "~2.4.4",
     "docpad-plugin-handlebars": "~2.3.0",
     "docpad-plugin-highlightjs": "~2.2.2",


### PR DESCRIPTION
Because docpad is installed globally (see: README.md), it shouldn't also be installed locally.

https://issues.fluidproject.org/browse/FLUID-5781