### PR TITLE
FLUID 5935: Update the TextToSpeech component docs

### DIFF
--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -15,7 +15,7 @@ The Text To Speech component can be used in browsers that support [Web Speech Sy
 * MS Edge 14 (in Preview Release)
 * Firefox 48+ (using the `media.webspeech.synth.enabled` about:config option)
 
-<div class="infusion-docs-note"><strong>Note:</strong> Find the latest browser support data for Web Speech Synthesis API from
+<div class="infusion-docs-note"><strong>Note:</strong> find the latest browser support data for Web Speech Synthesis API from
 <a href="http://caniuse.com/#feat=web-speech">caniuse.com</a>.</div>
 
 ## Creator ##
@@ -230,7 +230,7 @@ fluid.queueSpeech("Hello world", false, {
 
 ## Supported Events ##
 
-<div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the <a href="InfusionEventSystem.md">Infusion Event System</a> document for a full description of infusion events.</div>
+<div class="infusion-docs-note"><strong>Note:</strong> if needed, please read the <a href="InfusionEventSystem.md">Infusion Event System</a> document for a full description of infusion events.</div>
 
 The events fired by the Text To Speech component are described below.
 
@@ -379,11 +379,11 @@ The events fired by the Text To Speech component are described below.
 
 ## <a name="utteranceopts-option"></a>`model.utteranceOpts` Configuration ##
 
-<div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the <a href="ComponentConfigurationOptions.md">Component Configuration Options</a> document for a full description of infusion component options.</div>
+<div class="infusion-docs-note"><strong>Note:</strong> if needed, please read the <a href="ComponentConfigurationOptions.md">Component Configuration Options</a> document for a full description of infusion component options.</div>
 
 Configuration of the Text To Speech component can be done through `model.utteranceOpts`. This model path is a Javascript object that contains attributes that users can use to define the behaviour of the [SpeechSynthesisUtterance instance](https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#utterance-attributes) (a part of the web speech API that the Text To Speech component interacts with).
 
-<div class="infusion-docs-note"><strong>Note:</strong> Not all speech synthesizers support all these attributes and some may take different ranges.</div>
+<div class="infusion-docs-note"><strong>Note:</strong> not all speech synthesizers support all these attributes and some may take different ranges.</div>
 
 These attributes include:
 
@@ -395,7 +395,7 @@ These attributes include:
             <th>Description</th>
             <td>
                 The <code>text</code> attribute allows you to set the text that you wish to be spoken.
-                <div class="infusion-docs-note"><strong>Note:</strong>Be careful with this attribute as it will override any text that was previously passed.</div>                
+                <div class="infusion-docs-note"><strong>Note:</strong> be careful with this attribute as it will override any text that was previously passed.</div>                
             </td>
         </tr>
         <tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -4,10 +4,10 @@ layout: default
 category: Components
 ---
 
-The **Text To Speech** component uses [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#tts-section) to queue up and read texts.
+The **Text To Speech** component uses [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#tts-section) to queue up and read texts.
 
 ## Browser Support ##
-The Text To Speech component can be used in browsers that support [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#tts-section). At the time of writing, July 26 2016, these browsers include:
+The Text To Speech component can be used in browsers that support [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#tts-section). At the time of writing, July 26 2016, these browsers include:
 * Chrome 31+
 * Chrome for Android 40+
 * Safari 7.1+
@@ -381,7 +381,7 @@ The events fired by the Text To Speech component are described below.
 
 <div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the <a href="ComponentConfigurationOptions.md">Component Configuration Options</a> document for a full description of infusion component options.</div>
 
-Configuration of the Text To Speech component can be done through `model.utteranceOpts`. This model path is a Javascript object that contains attributes that users can use to define the behaviour of the [SpeechSynthesisUtterance instance](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#utterance-attributes) (a part of the web speech API that the Text To Speech component interacts with).
+Configuration of the Text To Speech component can be done through `model.utteranceOpts`. This model path is a Javascript object that contains attributes that users can use to define the behaviour of the [SpeechSynthesisUtterance instance](https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#utterance-attributes) (a part of the web speech API that the Text To Speech component interacts with).
 
 <div class="infusion-docs-note"><strong>Note:</strong> Not all speech synthesizers support all these attributes and some may take different ranges.</div>
 
@@ -465,7 +465,7 @@ fluid.textToSpeech({
         <tr>
             <th>Description</th>
             <td>
-                <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
+                <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
                 <div class="infusion-docs-note">Note that in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/onvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
             </td>
         </tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -465,8 +465,8 @@ fluid.textToSpeech({
         <tr>
             <th>Description</th>
             <td>
-                <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
-                <div class="infusion-docs-note">Note that in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/onvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
+                <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsgetvoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
+                <div class="infusion-docs-note">Note that in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsonvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
             </td>
         </tr>
         <tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -395,7 +395,7 @@ These attributes include:
             <th>Description</th>
             <td>
                 The <code>text</code> attribute allows you to set the text that you wish to be spoken.
-                <div class="infusion-docs-note"><strong>Note:</strong> Be careful with this attribute as it will override any text that was previously passed.</div>                
+                <div class="infusion-docs-note"><strong>Note:</strong>Be careful with this attribute as it will override any text that was previously passed.</div>                
             </td>
         </tr>
         <tr>
@@ -465,7 +465,7 @@ fluid.textToSpeech({
         <tr>
             <th>Description</th>
             <td>
-                <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsgetvoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
+                The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsgetvoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.
                 <div class="infusion-docs-note"><strong>Note:</strong> in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsonvoiceschanged">voiceschanged</a> event to get a full list.</div>        
             </td>
         </tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -7,11 +7,13 @@ category: Components
 The **Text To Speech** component uses [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#tts-section) to queue up and read texts.
 
 ## Browser Support ##
-The Text To Speech component can be used in browsers that support [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#tts-section). At the time of writing, Mar 4 2015, these browsers include:
+The Text To Speech component can be used in browsers that support [Web Speech Synthesis API](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#tts-section). At the time of writing, July 26 2016, these browsers include:
 * Chrome 31+
 * Chrome for Android 40+
 * Safari 7.1+
 * iOS Safari 7.1+
+* MS Edge 14 (in Preview Release)
+* Firefox 48+ (using the `media.webspeech.synth.enabled` about:config option)
 
 <div class="infusion-docs-note"><strong>Note:</strong> Find the latest browser support data for Web Speech Synthesis API from [caniuse.com](http://caniuse.com/#feat=web-speech).</div>
 
@@ -37,9 +39,9 @@ Use the following function to create a Text To Speech component:
             <th>Parameters</th>
             <td>
                 <dl>
-                    <dt>options</dt>
+                    <dt>model.utteranceOpts</dt>
                     <dd>
-                        An optional data structure that configures the Text To Speech component, as described below.
+                        An optional data structure supplied to the component model that configures the Text To Speech component behaviour, as described below. As part of the component model, can be managed through the [ChangeApplier API](ChangeApplierAPI.md) to assist in coordination with other components.
                     </dd>
                 </dl>
             </td>
@@ -54,9 +56,11 @@ Use the following function to create a Text To Speech component:
 <pre>
 <code>
 var tts = fluid.textToSpeech({
-    utteranceOpts: {
-        volume: 1
-    }
+    model: {
+        utteranceOpts: {
+            volume: 1
+        }
+    },
 });
 </code>
 </pre>
@@ -65,7 +69,7 @@ var tts = fluid.textToSpeech({
         <tr>
             <th>See also</th>
             <td>
-                <a href="#utteranceopts-option">Utteranceopts Option</a>
+                <a href="#utteranceopts-option">`model.utteranceOpts` Options</a>
             </td>
         </tr>
     </tbody>
@@ -103,7 +107,7 @@ var tts = fluid.textToSpeech({
                     </dd>
                     <dt>options</dt>
                     <dd>
-                        An optional javascript object. Allows for the configuration of the specific <code>SpeechSynthesisUtterance</code> instance used for this particular text. The configuration passed in here takes the same form as <a href="#utteranceopts-option">utteranceOpts</a> and will override them for this instance only.
+                        An optional javascript object. Allows for the configuration of the specific <code>SpeechSynthesisUtterance</code> instance used for this particular text. The configuration passed in here takes the same form as <a href="#utteranceopts-option">`model.utteranceOpts`</a> and will override them for this instance only.
                     </dd>
                 </dl>
             </td>
@@ -372,11 +376,11 @@ The events fired by the Text To Speech component are described below.
     </tbody>
 </table>
 
-## utteranceOpts` Option ##
+## <a name="utteranceopts-option"></a>`model.utteranceOpts` Configuration ##
 
 <div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the [Component Configuration Options](ComponentConfigurationOptions.md) document for a full description of infusion component options.</div>
 
-The only option supported by the Text To Speech component is `utteranceOpts`. This option is a javascript object that contains attributes that users can use to define the behaviour of the [SpeechSynthesisUtterance instance](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#utterance-attributes) (a part of the web speech API that the Text To Speech component interacts with).
+Configuration of the Text To Speech component can be done through `model.utteranceOpts`. This model path is a Javascript object that contains attributes that users can use to define the behaviour of the [SpeechSynthesisUtterance instance](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#utterance-attributes) (a part of the web speech API that the Text To Speech component interacts with).
 
 <div class="infusion-docs-note"><strong>Note:</strong> Not all speech synthesizers support all these attributes and some may take different ranges.</div>
 
@@ -405,8 +409,10 @@ These attributes include:
 <pre>
 <code>
 fluid.textToSpeech({
-    utteranceOpts: {
-        text: "Override other texts"
+    model: {
+        utteranceOpts: {
+            text: "Override other texts"
+        }
     }
 });
 </code>
@@ -438,8 +444,10 @@ fluid.textToSpeech({
 <pre>
 <code>
 fluid.textToSpeech({
-    utteranceOpts: {
-        lang: "en-US"
+    model: {
+        utteranceOpts: {
+            lang: "en-US"
+        }
     }
 });
 </code>
@@ -472,8 +480,10 @@ fluid.textToSpeech({
 <pre>
 <code>
 fluid.textToSpeech({
-    utteranceOpts: {
-        voiceURI: "Google UK English Male"
+    model: {
+        utteranceOpts: {
+            voiceURI: "Google UK English Male"
+        }
     }
 });
 </code>
@@ -511,8 +521,10 @@ fluid.textToSpeech({
 <pre>
 <code>
 fluid.textToSpeech({
-    utteranceOpts: {
-        volume: 0.5
+    model: {
+        utteranceOpts: {
+            volume: 0.5
+        }
     }
 });
 </code>
@@ -544,8 +556,10 @@ fluid.textToSpeech({
 <pre>
 <code>
 fluid.textToSpeech({
-    utteranceOpts: {
-        rate: 2.5
+    model: {
+        utteranceOpts: {
+            rate: 2.5
+        }
     }
 });
 </code>
@@ -577,8 +591,10 @@ fluid.textToSpeech({
 <pre>
 <code>
 fluid.textToSpeech({
-    utteranceOpts: {
-        pitch: 1.2
+    model: {
+        utteranceOpts: {
+            pitch: 1.2
+        }
     }
 });
 </code>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -69,7 +69,7 @@ var tts = fluid.textToSpeech({
         <tr>
             <th>See also</th>
             <td>
-                <a href="#utteranceopts-option">`model.utteranceOpts` Options</a>
+                <a href="#utteranceopts-option"><code>model.utteranceOpts</code> Options</a>
             </td>
         </tr>
     </tbody>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -15,7 +15,8 @@ The Text To Speech component can be used in browsers that support [Web Speech Sy
 * MS Edge 14 (in Preview Release)
 * Firefox 48+ (using the `media.webspeech.synth.enabled` about:config option)
 
-<div class="infusion-docs-note"><strong>Note:</strong> Find the latest browser support data for Web Speech Synthesis API from [caniuse.com](http://caniuse.com/#feat=web-speech).</div>
+<div class="infusion-docs-note"><strong>Note:</strong> Find the latest browser support data for Web Speech Synthesis API from
+<a href="http://caniuse.com/#feat=web-speech">caniuse.com</a>.</div>
 
 ## Creator ##
 
@@ -41,7 +42,7 @@ Use the following function to create a Text To Speech component:
                 <dl>
                     <dt>model.utteranceOpts</dt>
                     <dd>
-                        An optional data structure supplied to the component model that configures the Text To Speech component behaviour, as described below. As part of the component model, can be managed through the [ChangeApplier API](ChangeApplierAPI.md) to assist in coordination with other components.
+                        An optional data structure supplied to the component model that configures the Text To Speech component behaviour, as described below. As part of the component model, can be managed through the <a href="ChangeApplierAPI.md">ChangeApplier API</a> to assist in coordination with other components.
                     </dd>
                 </dl>
             </td>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -395,7 +395,7 @@ These attributes include:
             <th>Description</th>
             <td>
                 The <code>text</code> attribute allows you to set the text that you wish to be spoken.
-                <strong>Note</strong>: Be careful with this attribute as it will override any text that was previously passed.
+                <div class="infusion-docs-note"><strong>Note:</strong> Be careful with this attribute as it will override any text that was previously passed.</div>                
             </td>
         </tr>
         <tr>
@@ -466,7 +466,7 @@ fluid.textToSpeech({
             <th>Description</th>
             <td>
                 <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsgetvoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
-                <div class="infusion-docs-note">Note that in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsonvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
+                <div class="infusion-docs-note"><strong>Note:</strong> in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsonvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
             </td>
         </tr>
         <tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -378,7 +378,7 @@ The events fired by the Text To Speech component are described below.
 
 ## <a name="utteranceopts-option"></a>`model.utteranceOpts` Configuration ##
 
-<div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the [Component Configuration Options](ComponentConfigurationOptions.md) document for a full description of infusion component options.</div>
+<div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the <a href="ComponentConfigurationOptions.md">Component Configuration Options</a> document for a full description of infusion component options.</div>
 
 Configuration of the Text To Speech component can be done through `model.utteranceOpts`. This model path is a Javascript object that contains attributes that users can use to define the behaviour of the [SpeechSynthesisUtterance instance](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#utterance-attributes) (a part of the web speech API that the Text To Speech component interacts with).
 
@@ -458,13 +458,13 @@ fluid.textToSpeech({
 </table>
 
 ### voice ###
-<!-- See the errata at https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi-errata.html - SpeechSynthesisUtterance must be passed a SpeechSynthesisVoice object to configure the voice under the latest API -->
+
 <table>
     <tbody>
         <tr>
             <th>Description</th>
             <td>
-                The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechsynthesisvoice">`SpeechSynthesisVoice`</a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid `SpeechSynthesisVoice`.               
+                The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid `SpeechSynthesisVoice`, or you can call the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.             
             </td>
         </tr>
         <tr>
@@ -479,8 +479,7 @@ fluid.textToSpeech({
 <pre>
 <code>
 
-// Assuming an existing textToSpeech component
-var availableVoices = textToSpeech.getVoices();
+var availableVoices = SpeechSynthesis.getVoices();
 var voiceToUse = availableVoices[0];
 
 fluid.textToSpeech({

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -466,7 +466,7 @@ fluid.textToSpeech({
             <th>Description</th>
             <td>
                 <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsgetvoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
-                <div class="infusion-docs-note"><strong>Note:</strong> in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsonvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
+                <div class="infusion-docs-note"><strong>Note:</strong> in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-ttsonvoiceschanged">voiceschanged</a> event to get a full list.</div>        
             </td>
         </tr>
         <tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -108,7 +108,7 @@ var tts = fluid.textToSpeech({
                     </dd>
                     <dt>options</dt>
                     <dd>
-                        An optional javascript object. Allows for the configuration of the specific <code>SpeechSynthesisUtterance</code> instance used for this particular text. The configuration passed in here takes the same form as <a href="#utteranceopts-option">`model.utteranceOpts`</a> and will override them for this instance only.
+                        An optional javascript object. Allows for the configuration of the specific <code>SpeechSynthesisUtterance</code> instance used for this particular text. The configuration passed in here takes the same form as <a href="#utteranceopts-option"><code>model.utteranceOpts</code></a> and will override them for this instance only.
                     </dd>
                 </dl>
             </td>
@@ -230,7 +230,7 @@ fluid.queueSpeech("Hello world", false, {
 
 ## Supported Events ##
 
-<div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the [Infusion Event System](InfusionEventSystem.md) document for a full description of infusion events.</div>
+<div class="infusion-docs-note"><strong>Note:</strong> If needed, please read the <a href="InfusionEventSystem.md">Infusion Event System</a> document for a full description of infusion events.</div>
 
 The events fired by the Text To Speech component are described below.
 
@@ -465,7 +465,8 @@ fluid.textToSpeech({
         <tr>
             <th>Description</th>
             <td>
-                The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid `SpeechSynthesisVoice`, or you can call the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.             
+                <p>The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechsynthesisvoice"><code>SpeechSynthesisVoice</code></a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid <code>SpeechSynthesisVoice</code>, or you can call the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices">SpeechSynthesis.getVoices()</a></code> function of the browser directly.</p>     
+                <div class="infusion-docs-note">Note that in some browsers (such as Chrome), the voice list is populated after the page is loaded, and you may need to wait for the <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/onvoiceschanged">onvoiceschanged</a> event to get a full list.</div>        
             </td>
         </tr>
         <tr>

--- a/src/documents/TextToSpeechAPI.md
+++ b/src/documents/TextToSpeechAPI.md
@@ -457,15 +457,14 @@ fluid.textToSpeech({
     </tbody>
 </table>
 
-### voiceURI ###
-
+### voice ###
+<!-- See the errata at https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi-errata.html - SpeechSynthesisUtterance must be passed a SpeechSynthesisVoice object to configure the voice under the latest API -->
 <table>
     <tbody>
         <tr>
             <th>Description</th>
             <td>
-                The <code>voiceURI</code> attribute is a string that specifies the speech synthesis voice and the location of the speech synthesis service that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can get the value of the <code>voiceURI</code> attribute.<br />
-                <strong>Note</strong>: In Chrome and Safari, the <code>voiceURI</code> attribute is named <code>voice</code> instead.
+                The <code>voice</code> attribute must be a <a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechsynthesisvoice">`SpeechSynthesisVoice`</a> object that specifies the speech synthesis voice that the web application wishes to use. Calling the <a href="#getvoices">getVoices</a> method returns an array of all available voices, from which you can select a valid `SpeechSynthesisVoice`.               
             </td>
         </tr>
         <tr>
@@ -479,10 +478,15 @@ fluid.textToSpeech({
             <td>
 <pre>
 <code>
+
+// Assuming an existing textToSpeech component
+var availableVoices = textToSpeech.getVoices();
+var voiceToUse = availableVoices[0];
+
 fluid.textToSpeech({
     model: {
         utteranceOpts: {
-            voiceURI: "Google UK English Male"
+            voice: voiceToUse
         }
     }
 });

--- a/src/static/css/infusion-docs.css
+++ b/src/static/css/infusion-docs.css
@@ -361,6 +361,12 @@ div.infusion-docs-note {
     margin-bottom: 2rem;
 }
 
+/* Note style for use inside table cells */
+table div.infusion-docs-note {
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+}
+
 .infusion-docs-callout {
     font-family: "RobotoSlab";
     margin: 1rem;


### PR DESCRIPTION
This addresses two issues in our documentation about the TextToSpeech component:

* the current version of the component expects the speech options to be configured as part of the component model, while the current version of the documentation specifies configuring it as part of the top-level options block

* per the errata at https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi-errata.html, `voiceURI` is no longer used by the `SpeechSynthesisUtterance` interface; instead, the `voice` attribute can be passed a `SpeechSynthesisVoice` object to configure the voice synth to be used, typically after retrieving it via the `getVoices()` method or similar.

Longer term we may want to refactor this component design - under the current implementation configuring the voice synthesizer requires storing the `SpeechSynthesisVoice` object on the model, and I'm not certain without further experimentation if this is a copy-safe operation (that is, does the `voice` attribute expect and validate for a `SpeechSynthesisVoice` object, or will any POJO with the correct attributes suffice). However, this PR brings the documentation in line with our own implementation and the current API.