### PR TITLE
NOJIRA: small correction to documentation

### DIFF
--- a/src/documents/CoreAPI.md
+++ b/src/documents/CoreAPI.md
@@ -320,7 +320,7 @@ Return the keys in the supplied object as an array. Note that this will return k
 * `object {Object}` The object to have its values listed
 * Returns: `{Array}` An array holding the values of this object.
 
-Return the keys in the supplied object as an array. This will return values found in the prototype chain as well as those attached to "own properties".
+Return the values in the supplied object as an array. This will return values found in the prototype chain as well as those attached to "own properties".
 
 
 ### fluid.arrayToHash(array)


### PR DESCRIPTION
This corrects a small (presumed copy-paste originating) error in the documentation that we found during the pair programming community meeting.

`fluid.values` was stating it returned the keys of a supplied object as an array; as might be expected, it in fact returns the values, and `fluid.keys` is the equivalent key-listing function. 💯 