### PR TITLE
FLUID-5686: Added migration docs

### DIFF
--- a/site-structure.json
+++ b/site-structure.json
@@ -135,14 +135,15 @@
                 "sectionName": "Migrating to Infusion 2.0",
                 "pages":
                 [
-                    { "pageName": "API Changes from 1.5 to 2.0", "href": "/APIChangesFrom1_5To2_0.html" }
+                    { "pageName": "API Changes from 1.5 to 2.0", "href": "/APIChangesFrom1_5To2_0.html" },
+                    { "pageName": "Deprecated in 2.0", "href": "/DeprecatedIn2_0.html" }
                 ]
             },
             {
-                "sectionName": "Deprecations",
+                "sectionName": "Migrating to Infusion 3.0",
                 "pages":
                 [
-                    { "pageName": "Deprecated in 2.0", "href": "/DeprecatedIn2_0.html" }
+                    { "pageName": "API Changes from 2.0 to 3.0", "href": "/APIChangesFrom2_0To3_0.html" }
                 ]
             }
         ]

--- a/src/documents/APIChangesFrom2_0To3_0.md
+++ b/src/documents/APIChangesFrom2_0To3_0.md
@@ -1,0 +1,33 @@
+---
+title: API Changes from 2.0 to 3.0
+layout: default
+category: Infusion
+---
+
+This page contains a list of the features, APIs, and etc. that have changed in Infusion 3.0.
+
+## Framework Changes ##
+
+### Core Framework Changes ###
+
+This section describes major APIs that were in common use. For information about less widely-used features removed in 3.0, consult [Deprecations in 2.0](DeprecatedIn2_0.md).
+
+
+### Preferences Framework ###
+
+#### Panel Changes ####
+
+"Links and Buttons" adjuster and enactors collapsed to a single preference, "Enhance Links"
+
+##### Message Bundle Keys #####
+
+###### Additions ######
+
+* tableOfContents.json
+  * `toggleOn`
+  * `toggleOff`
+* enhanceInputs.json
+  * `label`
+  * `descr`
+  * `toggleOn`
+  * `toggleOff`

--- a/src/documents/APIChangesFrom2_0To3_0.md
+++ b/src/documents/APIChangesFrom2_0To3_0.md
@@ -17,7 +17,7 @@ This section describes major APIs that were in common use. For information about
 
 #### Panel Changes ####
 
-"Links and Buttons" adjuster and enactors collapsed to a single preference, "Enhance Links"
+The "Links and Buttons" adjusters and enactors are collapsed to a single preference called "Enhance Links".
 
 ##### Message Bundle Keys #####
 
@@ -34,6 +34,12 @@ This section describes major APIs that were in common use. For information about
 * tableOfContents.json
   * `"switchOn"`
   * `"switchOff"`
+
+###### Removals ######
+
+* inputsLarger.json
+* emphasizeLinks.json
+* linksControls.json
 
 ###### Changes ######
 


### PR DESCRIPTION
Added migration docs which mention the change from emphasize links and inputs larger to enhance inputs.

https://issues.fluidproject.org/browse/FLUID-5686

Related PR: https://github.com/fluid-project/infusion/pull/815