### PR TITLE
FLUID-6197: correct path to set locale on preferencesEditorLoader

### DIFF
--- a/src/documents/LocalizationInThePreferencesFramework.md
+++ b/src/documents/LocalizationInThePreferencesFramework.md
@@ -255,7 +255,7 @@ that.msgLookup.lookup(value); // where value is either the string name or the ke
 
 ## Specifying a Localization
 
-The messageLoader is implemented using [fluid.resourceLoader](ResourceLoader.md). It takes `defaultLocale` and `locale` options for specifying which localized Message Bundle to fetch. The `locale` option specifies the localization desired. By default it is sourced from the prefsEditorLoader's settings object, `"{prefsEditorLoader}.settings.locale"`. The `defaultLocale` provides a fallback to use if the desired localization cannot be located. By default it is sourced from the prefsEditorLoader's `defaultLocale` option.
+The messageLoader is implemented using [fluid.resourceLoader](ResourceLoader.md). It takes `defaultLocale` and `locale` options for specifying which localized Message Bundle to fetch. The `locale` option specifies the localization desired. By default it is sourced from the prefsEditorLoader's settings object, `"{prefsEditorLoader}.settings.preferences.locale"`. The `defaultLocale` provides a fallback to use if the desired localization cannot be located. By default it is sourced from the prefsEditorLoader's `defaultLocale` option.
 
 See [fluid.resourceLoader options](ResourceLoader.html#options) for the accepted form of ```locale``` and ```defaultLocale```.
 See [fluid.resourceLoader fallback rules](ResourceLoader.html#fallback-rules-with-locale-and-defaultlocale) for fallback rules when attempting to locate a localization.

--- a/src/documents/tutorial-userInterfaceOptions/UserInterfaceOptions.md
+++ b/src/documents/tutorial-userInterfaceOptions/UserInterfaceOptions.md
@@ -44,33 +44,39 @@ The rest of this tutorial will explain each of these steps in detail.
 3. Your `infusion` folder will include a single file containing all of the JavaScript you need (`infusion-uiOptions.js`), HTML templates, CSS files, and other components to get UI Options to work. You will later link to these files in your HTML files.
 4. Now that `infusion` is in your project directory, you can delete the `infusion-uiOptions-2.0.0.zip` (or similar name) from your download directory.
 
-###  Full Infusion library via NPM
+### Full Infusion library via NPM
 
 <strong>Note: </strong>
 This section assumes that you have [NPM/node.js](https://nodejs.org/en/) installed in your computer.
 
-1.  Get Infusion by typing the following in the command line (A new directory called `node_modules/infusion` will be created as a result): 
-```
+1. Get Infusion by typing the following in the command line (A new directory called `node_modules/infusion` will be created as a result):
+
+```bash
 npm install infusion
-``` 
+```
 
 2. Using the command line, change directory into the infusion directory that's been created within node_modules.
 
-* On Windows type: 
+* On Windows type:
+
 ```cmd
 cd node_modules\infusion
 ```
+
 * On Mac type:
+
 ```bash
 cd node_modules/infusion
 ```
+
 3. Now build Infusion by typing in:
 
-```
+```bash
 npm install
 grunt
-``` 
-4. This will create a "products" directory in the Infusion directory. Within the `project_name/node_modules/infusion/products` directory, there is now a ZIP file called "infusion-all-2.0.0.zip" (the exact filename may be a little different depending on the release of Infusion available at the time you download it). 
+```
+
+4. This will create a "products" directory in the Infusion directory. Within the `project_name/node_modules/infusion/products` directory, there is now a ZIP file called "infusion-all-2.0.0.zip" (the exact filename may be a little different depending on the release of Infusion available at the time you download it).
 
 5. Unzip this file using your preferred Unzipping program. Now move the resulting "infusion" directory to a location within your project.<div class="infusion-docs-note"><strong>Note:</strong> In this guide we will use the directory `my-project/lib/`.</div>
 


### PR DESCRIPTION
- correct path to set locale on preferencesEditorLoader
- fix linting in another file

See comment here - it appears the path for setting `locale` changed recently (in https://github.com/fluid-project/infusion/commit/1a466e1f9188b23ccf8da90c249cafab953b7865#diff-4b9c9b993efab504ef58b9664e518698R67) from `{prefsEditorLoader}.settings.locale` to `{prefsEditorLoader}.settings.preferences.locale`, but the documentation was not updated.

@jobara could you have a look at this documentation change? It's very minor but we're also not sure (@waharnum writing this comment under @BlueSlug's account as we pair) that this part of the documentation is correct even with the path updated, given the other changes.