### PR TITLE
FLUID-6324: patch for 6.82.5 release of DocPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ docpad run --env static
 
 Point your browser to: `http://localhost:9778/`
 
+## Deployment
+
+1. Generate the static site: `docpad generate --env static`
+2. Commit the contents of `out` directory to the `deploy` branch (we are currently doing this manually, as the plugin we relied on previously is broken); when changes are pushed or merged to the `deploy` branch of the `fluid-project/infusion-docs` repo, CI will pick up and deploy them automatically
+
 ## A Note on DocPad plugins
 
 Changes to DocPad plugins used by this package only take effect when your `node_modules` directory is up to date.  It is

--- a/README.md
+++ b/README.md
@@ -32,26 +32,6 @@ docpad run --env static
 
 Point your browser to: `http://localhost:9778/`
 
-## Deploy
-
-While GitHub Pages is not used to host [fluiproject.org](https://docs.fluidproject.org), our deployment process requires that the generated site be pushed to the `deploy` branch in the project repo. The contents of the `deploy` branch will automatically be served as the contents are changed.
-
-To generate and push to the `deploy` branch on the project repo run the following:
-
-```shell
-npm run deploy
-```
-
-This runs the command:
-
-```shell
-docpad deploy-ghpages --env static
-```
-
-_**WARNING:** Deploying will upload the site to the `deploy` branch of the `origin` remote. If you have cloned
-from the production repository and you have push access, you will actually run the docs publication
-workflow against the live production branch, regardless of whichever branch you happen to be working on._
-
 ## A Note on DocPad plugins
 
 Changes to DocPad plugins used by this package only take effect when your `node_modules` directory is up to date.  It is

--- a/docpad.js
+++ b/docpad.js
@@ -89,44 +89,44 @@ module.exports = {
             }
         }
     },
-    // events: {
-    //     generateBefore: function () {
-    //         // Remove the previous incarnation of index.html since it causes a faulty redirect
-    //         fs.removeSync("out/index.html");
-    //     },
-    //     writeAfter: function () {
-    //         // Copy the images
-    //         fs.copySync(imagesSrcDir, imagesDestDir);
-    //
-    //         // Copy the contents of the out directory to
-    //         // out/infusion/<version>. We need to do this to prepare the
-    //         // structure for the ghpages plugin as it does not support
-    //         // deploying to a location other than the root.
-    //         fs.removeSync("tmp-out");
-    //         try {
-    //             fs.renameSync("out", "tmp-out");
-    //             fs.mkdirsSync("out");
-    //         } catch (e) {
-    //             console.log("Failed to rename out to tmp-out - copying instead: error ", e);
-    //             fs.copySync("out", "tmp-out");
-    //             try {
-    //                 fs.emptyDirSync("out");
-    //             } catch (e2) {
-    //                 console.log("Failed to empty dir out: error ", e2);
-    //             }
-    //         }
-    //         // Preserve anything that was correctly dumped into "infusion" on the previous round
-    //         if (fs.existsSync("tmp-out/infusion")) {
-    //             fs.renameSync("tmp-out/infusion", "out/infusion");
-    //         }
-    //
-    //         // Anything that was generated on this round gets copied into infusion
-    //         fs.copySync("tmp-out", "out/infusion/" + docsVersion);
-    //         fs.removeSync("tmp-out");
-    //
-    //         // Copy the files for GitHub Pages:
-    //         // redirect index.htmls and CNAME
-    //         fs.copySync(path.join(rootPath, "src", "ghpages-files"), "out");
-    //     }
-    // }
+    events: {
+        generateBefore: function () {
+            // Remove the previous incarnation of index.html since it causes a faulty redirect
+            fs.removeSync("out/index.html");
+        },
+        writeAfter: function () {
+            // Copy the images
+            fs.copySync(imagesSrcDir, imagesDestDir);
+
+            // Copy the contents of the out directory to
+            // out/infusion/<version>. We need to do this to prepare the
+            // structure for the ghpages plugin as it does not support
+            // deploying to a location other than the root.
+            fs.removeSync("tmp-out");
+            try {
+                fs.renameSync("out", "tmp-out");
+                fs.mkdirsSync("out");
+            } catch (e) {
+                console.log("Failed to rename out to tmp-out - copying instead: error ", e);
+                fs.copySync("out", "tmp-out");
+                try {
+                    fs.emptyDirSync("out");
+                } catch (e2) {
+                    console.log("Failed to empty dir out: error ", e2);
+                }
+            }
+            // Preserve anything that was correctly dumped into "infusion" on the previous round
+            if (fs.existsSync("tmp-out/infusion")) {
+                fs.renameSync("tmp-out/infusion", "out/infusion");
+            }
+
+            // Anything that was generated on this round gets copied into infusion
+            fs.copySync("tmp-out", "out/infusion/" + docsVersion);
+            fs.removeSync("tmp-out");
+
+            // Copy the files for GitHub Pages:
+            // redirect index.htmls and CNAME
+            fs.copySync(path.join(rootPath, "src", "ghpages-files"), "out");
+        }
+    }
 };

--- a/docpad.js
+++ b/docpad.js
@@ -87,55 +87,46 @@ module.exports = {
                 snippet: "shell",
                 stylus:  "css"
             }
-        },
-        markit: {
-            html: true,
-            plugins: ["markdown-it-anchor"],
-            "markdown-it-anchor": {}
-        },
-        ghpages: {
-            deployRemote: "origin",
-            deployBranch: "deploy"
         }
     },
-    events: {
-        generateBefore: function () {
-            // Remove the previous incarnation of index.html since it causes a faulty redirect
-            fs.removeSync("out/index.html");
-        },
-        writeAfter: function () {
-            // Copy the images
-            fs.copySync(imagesSrcDir, imagesDestDir);
-
-            // Copy the contents of the out directory to
-            // out/infusion/<version>. We need to do this to prepare the
-            // structure for the ghpages plugin as it does not support
-            // deploying to a location other than the root.
-            fs.removeSync("tmp-out");
-            try {
-                fs.renameSync("out", "tmp-out");
-                fs.mkdirsSync("out");
-            } catch (e) {
-                console.log("Failed to rename out to tmp-out - copying instead: error ", e);
-                fs.copySync("out", "tmp-out");
-                try {
-                    fs.emptyDirSync("out");
-                } catch (e2) {
-                    console.log("Failed to empty dir out: error ", e2);
-                }
-            }
-            // Preserve anything that was correctly dumped into "infusion" on the previous round
-            if (fs.existsSync("tmp-out/infusion")) {
-                fs.renameSync("tmp-out/infusion", "out/infusion");
-            }
-
-            // Anything that was generated on this round gets copied into infusion
-            fs.copySync("tmp-out", "out/infusion/" + docsVersion);
-            fs.removeSync("tmp-out");
-
-            // Copy the files for GitHub Pages:
-            // redirect index.htmls and CNAME
-            fs.copySync(path.join(rootPath, "src", "ghpages-files"), "out");
-        }
-    }
+    // events: {
+    //     generateBefore: function () {
+    //         // Remove the previous incarnation of index.html since it causes a faulty redirect
+    //         fs.removeSync("out/index.html");
+    //     },
+    //     writeAfter: function () {
+    //         // Copy the images
+    //         fs.copySync(imagesSrcDir, imagesDestDir);
+    //
+    //         // Copy the contents of the out directory to
+    //         // out/infusion/<version>. We need to do this to prepare the
+    //         // structure for the ghpages plugin as it does not support
+    //         // deploying to a location other than the root.
+    //         fs.removeSync("tmp-out");
+    //         try {
+    //             fs.renameSync("out", "tmp-out");
+    //             fs.mkdirsSync("out");
+    //         } catch (e) {
+    //             console.log("Failed to rename out to tmp-out - copying instead: error ", e);
+    //             fs.copySync("out", "tmp-out");
+    //             try {
+    //                 fs.emptyDirSync("out");
+    //             } catch (e2) {
+    //                 console.log("Failed to empty dir out: error ", e2);
+    //             }
+    //         }
+    //         // Preserve anything that was correctly dumped into "infusion" on the previous round
+    //         if (fs.existsSync("tmp-out/infusion")) {
+    //             fs.renameSync("tmp-out/infusion", "out/infusion");
+    //         }
+    //
+    //         // Anything that was generated on this round gets copied into infusion
+    //         fs.copySync("tmp-out", "out/infusion/" + docsVersion);
+    //         fs.removeSync("tmp-out");
+    //
+    //         // Copy the files for GitHub Pages:
+    //         // redirect index.htmls and CNAME
+    //         fs.copySync(path.join(rootPath, "src", "ghpages-files"), "out");
+    //     }
+    // }
 };

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     },
     "dependencies": {
         "docpad": "6.82.5",
-        "docpad-plugin-handlebars": "github:waharnum/docpad-plugin-handlebars#fixFor6.8",
+        "docpad-plugin-handlebars": "github:waharnum/docpad-plugin-handlebars#fixFor6.8-build",
         "docpad-plugin-highlightjs": "2.6.0",
         "docpad-plugin-marked": "2.5.0",
+        "docpad-plugin-serve": "2.0.1",
         "fs-extra": "7.0.1",
         "urijs": "1.19.1"
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "docpad": "6.82.5",
-        "docpad-plugin-handlebars": "2.5.0",
+        "docpad-plugin-handlebars": "github:waharnum/docpad-plugin-handlebars#fixFor6.8",
         "docpad-plugin-highlightjs": "2.6.0",
         "docpad-plugin-marked": "2.5.0",
         "fs-extra": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -6,28 +6,26 @@
     "repository": "https://github.com/fluid-project/infusion-docs",
     "scripts": {
         "docpad": "docpad run --env static --out out",
-        "deploy": "docpad deploy-ghpages --env static",
         "pretest": "docpad generate --env static --out out",
         "test": "node tests/all-tests.js"
     },
     "dependencies": {
-        "urijs": "1.19.0",
-        "docpad-plugin-ghpages": "2.6.1",
-        "docpad-plugin-handlebars": "2.4.0",
-        "docpad-plugin-highlightjs": "2.5.0",
-        "docpad-plugin-markit": "2.4.0",
-        "fs-extra": "4.0.2",
-        "markdown-it-anchor": "4.0.0"
+        "docpad": "6.82.5",
+        "docpad-plugin-handlebars": "2.5.0",
+        "docpad-plugin-highlightjs": "2.6.0",
+        "docpad-plugin-marked": "2.5.0",
+        "fs-extra": "7.0.1",
+        "urijs": "1.19.1"
     },
     "devDependencies": {
         "eslint-config-fluid": "1.3.0",
-        "gpii-grunt-lint-all": "1.0.5-dev.20180904T103657Z.c351ca9",
-        "gpii-express": "1.0.11",
-        "grunt": "1.0.1",
+        "gpii-grunt-lint-all": "1.0.5",
+        "gpii-express": "1.0.15",
+        "grunt": "1.0.3",
         "infusion": "3.0.0-dev.20171006T195039Z.a128358",
-        "jsdom": "11.3.0",
-        "kettle": "1.7.0",
-        "node-jqunit": "1.1.7",
-        "request": "2.83.0"
+        "jsdom": "13.0.0",
+        "kettle": "1.9.0",
+        "node-jqunit": "1.1.8",
+        "request": "2.88.0"
     }
 }


### PR DESCRIPTION
This is a patch to allow us to build and deploy the documentation under a version of DocPad compatible with Node 10.

It makes the following substantive changes:
- bumps the DocPad version to 6.82.5
- adds the `serve` plugin to maintain static server support (DocPad made this a plugin rather than a built-in for the 6.8 line)
- uses my forked and built version of the `handlebars` plugin, updated for compatibility with the 6.8 line: https://github.com/waharnum/docpad-plugin-handlebars/tree/fixFor6.8-build - I've had an outstanding pull request on the fix for this plugin since last December, but it has yet to be merged (https://github.com/docpad/docpad-plugin-handlebars/pull/13)

This should allow us to build and deploy the documentation in our usual way, in the immediate term.