### PR TITLE
FLUID-6469: fixing images

### DIFF
--- a/src/documents/tutorial-prefsFramework/CreatingAPrefsEditor.md
+++ b/src/documents/tutorial-prefsFramework/CreatingAPrefsEditor.md
@@ -30,7 +30,7 @@ code for the simple Preference Editor in the examples folder:
 We recommend you download the Infusion library and load the example code into your favourite editor.
 
 <figure>
-    ![the folder hierarchy of the sample code](../images/prefsEditorFolders.png)
+    <img src="../images/prefsEditorFolders.png" alt="the folder hierarchy of the sample code">
     <figcaption>Figure 1: Folder hierarchy for the Preference Editor example</figcaption>
 </figure>
 
@@ -40,7 +40,7 @@ approach](http://www.linuxjournal.com/content/tech-tip-really-simple-http-server
 [MAMP](https://www.mamp.info/en/)) and navigate to the `index.html` file in a browser, you should see this interface:
 
 <figure id="figure2">
-    ![The screen of the example Preference Editor](../images/simplePrefsEditor.png)
+    <img src="../images/simplePrefsEditor.png" alt="The screen of the example Preference Editor">
     <figcaption>Figure 2: The screen of the example Preference Editor</figcaption>
 </figure>
 
@@ -51,7 +51,7 @@ cookie, and when you reload the page, the checkbox will be set to the saved valu
 Let’s talk about what we’re seeing in this interface:
 
 <figure>
-    ![The parts of a Preference Editor screen](../images/prefsEditorParts.png)
+    <img src="../images/prefsEditorParts.png" alt="The parts of a Preference Editor screen">
     <figcaption>Figure 3: The parts of a Preference Editor screen</figcaption>
 </figure>
 


### PR DESCRIPTION
issue page: https://docs.fluidproject.org/infusion/development/tutorial-prefsFramework/CreatingAPrefsEditor.html#figure2
fixes [FLUID-6469](https://issues.fluidproject.org/browse/FLUID-6469)
Screenshot:
![Screenshot from 2020-03-19 03-52-07](https://user-images.githubusercontent.com/34926285/77012989-1b764200-6995-11ea-94a7-eb90f56f8904.png)
![Screenshot from 2020-03-19 03-52-22](https://user-images.githubusercontent.com/34926285/77012992-1d400580-6995-11ea-8a26-0074c77bcef8.png)
![Screenshot from 2020-03-19 03-52-35](https://user-images.githubusercontent.com/34926285/77012994-1dd89c00-6995-11ea-9be3-a4b88c64f0da.png)

P.S. images do not get rendered if they are used in MD format links inside a semantic HTML tag. I included them inside <img> tag, (could have been solved by removing <figure> tag too)
