### PR TITLE
FLUID-6484: Using an alternative request library

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "jsdom": "11.3.0",
         "kettle": "1.7.0",
         "node-jqunit": "1.1.7",
-        "request": "2.83.0",
+        "urllib": "^2.34.2",
         "testem": "2.15.1"
     }
 }

--- a/tests/js/lib/link-checker.js
+++ b/tests/js/lib/link-checker.js
@@ -19,7 +19,7 @@
 /* eslint-env node */
 "use strict";
 var fluid   = require("infusion");
-var request = require("request");
+var urllib = require('urllib');
 var url     = require("url");
 var jsdom   = require("jsdom");
 
@@ -45,7 +45,7 @@ fluid.tests.docs.linkChecker.scanSinglePageOrFinish = function (that) {
         }
         else {
             // Retrieve the page and process it.
-            request(pageToScan, function (error, response, body) {
+            urllib.request(pageToScan,function(error,body,response){
                 fluid.tests.docs.linkChecker.processSingleResponse(that, pageToScan, error, response, body);
                 promise.resolve();
             });
@@ -132,7 +132,7 @@ fluid.tests.docs.linkChecker.processSingleResponse = function (that, pageToScan,
         pageResults.error = error;
     }
     else if (body) {
-        var dom = new jsdom.JSDOM(body);
+        var dom = new jsdom.JSDOM(body.toString());
 
         // Add the page's elements with IDs to our map of known placeholders.
         var pageIdNodeList = dom.window.document.querySelectorAll("[id]");


### PR DESCRIPTION
Request has been deprecated by its core and makes sense not to use again in the infusion documentation platform.A similar alternative with same structure and approach Urlib is used instead.
fixes https://issues.fluidproject.org/browse/FLUID-6484