### PR TITLE
FLUID-5829: Make the links more specific and reliable

### DIFF
--- a/src/documents/HowToUseTheRenderer.md
+++ b/src/documents/HowToUseTheRenderer.md
@@ -13,7 +13,7 @@ Component and various Renderer functions.
 ### Renderer Component
 
 If you are creating a component that requires the use of the Renderer, you should use the `fluid.rendererComponent`
-grade as a [parent grade](ComponentGrades.md) in your component's defaults block:
+grade as a [parent grade](ComponentGrades.md#specifying-parent-grades) in your component's defaults block:
 
 ```javascript
 fluid.defaults("my.component", {
@@ -38,7 +38,7 @@ For detailed information on how to use this method, see [Renderer Components](Re
 ### fluid.render
 
 If you are not using `fluid.rendererComponent`, you can use the primary renderer function,
-[fluid.render](https://github.com/fluid-project/infusion/blob/infusion-1.5/src/framework/renderer/js/fluidRenderer.js#L1551-L1570):
+[fluid.render](https://github.com/fluid-project/infusion/blob/87616ab067769ce04623b5928dfded5ccddeb4da/src/framework/renderer/js/fluidRenderer.js#L1551-L1570):
 
 ```javascript
 var template = fluid.render(source, target, tree, options);

--- a/src/documents/Renderer.md
+++ b/src/documents/Renderer.md
@@ -8,7 +8,7 @@ category: Infusion
 The Infusion Framework includes a client-side **Renderer** that allows users to create user interface templates in pure
 HTML, and render the pages entirely on the client side. The Renderer offers a clean separation of Model and View: it
 works with internal [Renderer Component Trees](RendererComponentTrees.md) that are independent of the mark-up,
-supporting the Infusion goal of [markup agnosticism](FrameworkConcepts.md).
+supporting the Infusion goal of [markup agnosticism](FrameworkConcepts.md#markup-agnosticism).
 
 This page provides resources to help you learn about the Renderer and how to use it.
 


### PR DESCRIPTION
This PR:
- Links the specific sections of `ComponentGrades` and `FrameworkConcepts` rather than the whole page.
- Replaces the GitHub link with permalink in HowToUseTheRenderer.md so that it always points to the desired location irrespective of the changes in the branch.

Fixes [FLUID-5829](https://issues.fluidproject.org/browse/FLUID-5829)