### PR TITLE
FLUID-6376: Made the site navigation responsive

### DIFF
--- a/src/static/css/infusion-docs.css
+++ b/src/static/css/infusion-docs.css
@@ -632,3 +632,27 @@ Instead have it appear around the enclosed
 .search-result-sub-entry {
     border-top: 1px solid #ffffff;
 }
+
+@media only screen and (max-width: 639px) {
+    .infusion-docs-container .infusion-docs-header {
+        height: 10rem;
+    }
+    .infusion-docs-container .infusion-docs-fluidLogo {
+        margin-top: 3.5rem;
+    }
+    .infusion-docs-header .infusion-docs-fluidCategories {
+        margin-top: -3rem;
+    }
+    .infusion-docs-TOC {
+        border-top: 10rem solid;
+    }
+}
+
+@media only screen and (max-width: 470px) {
+    .infusion-docs-container .infusion-docs-header {
+        height: 12.5rem;
+    }
+    .infusion-docs-TOC {
+        border-top: 12rem solid;
+    }
+}


### PR DESCRIPTION
Currently, the top navigation bar is not at all responsive and becomes extremely unable to use on mobile devices and other smaller devices. This PR aims to fix this.

The necessary breakpoints and their respective screenshots are posted in the corresponding [issue](https://issues.fluidproject.org/browse/FLUID-6376)