### PR TITLE
typo fix:in iocAPI externalisable->externalizable

### DIFF
--- a/src/documents/IoCAPI.md
+++ b/src/documents/IoCAPI.md
@@ -6,7 +6,7 @@ category: Infusion
 
 Whilst Infusion's [IoC](HowToUseInfusionIoC.md) is primarily a declarative system, operated by a declarative dialect of
 JSON configuration, there are a few language-level APIs which are useful in dealing with the system. Some of these are
-externalisable in that there is a reasonable semantic for operating them from outside the JavaScript VM housing the
+externalizable in that there is a reasonable semantic for operating them from outside the JavaScript VM housing the
 component tree - these special APIs are grouped under the heading [Nexus API methods](#nexus-api-methods), named after
 the [Nexus component](https://wiki.gpii.net/w/Nexus_API) that will shortly be built around them.
 


### PR DESCRIPTION
fix - issue #184 
typo fix: externalisable->externalizable
Under API in iocAPI. 