### PR TITLE
FLUID-6288 Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:12.18.0-alpine AS builder
+
+WORKDIR /app
+
+RUN apk add --no-cache git 
+
+COPY package.json ./
+
+RUN npm install
+
+COPY . ./
+
+# The echo command is necessary to work around a bug in docpad 6.79.4
+RUN echo | $(npm bin)/docpad generate --env static --silent 
+
+
+FROM nginx:1.18.0-alpine
+
+COPY --from=builder /app/out /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ npm run docpad
 
 Then, point your browser to: `http://localhost:9778/`
 
+## Generating a Docker image
+
+You can serve the website from a [Docker](https://docs.docker.com/get-docker) container.
+
+Once you have Docker installed, run the following commands to build a Docker image and start a container:
+
+* Build the image: `docker build -t infusion-docs .`
+* Run the container: `docker run --name infusion-docs -p 8000:80 infusion-docs`
+
+The documentation will be available at [http://localhost:8000](http://localhost:8000)
+
+* To stop and remove the container: `docker rm -f infusion-docs`
+
+If you make changes to the documentation, repeat the steps to build the image and start a new container.
+
 ## Deploy
 
 While GitHub Pages is not used to host [fluidproject.org](https://docs.fluidproject.org), our deployment process requires


### PR DESCRIPTION
This is necessary so a Docker image can be created and used to serve the website.

To test:

```
$ docker build -t infusion-docs .
$ docker run --rm -ti -p 8000:80 infusion-docs
$ open http://localhost:8000
```

This PR was submitted and closed before because it couldn't build. This is a new PR with the fix/workaround necessary to make DocPad work inside a Docker container.