### PR TITLE
GH-225: align slugs with GitHub’s algorithm

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,13 +11,10 @@
 */
 "use strict";
 
-var slugify = require("slugify");
-var cleanSlugify = function (string) {
-    return slugify(string, {
-        replacement: "-",
-        lower: true,
-        strict: true
-    });
+var GithubSlugger = require("github-slugger");
+var githubSlugify = function (string) {
+    var slugger = new GithubSlugger();
+    return slugger.slug(string);
 };
 
 require("./index.js");
@@ -41,7 +38,7 @@ module.exports = function (eleventyConfig) {
     });
 
     var markdownItAnchor = require("markdown-it-anchor");
-    var markdownItLibrary = markdownit.use(markdownItAnchor, { slugify: cleanSlugify });
+    var markdownItLibrary = markdownit.use(markdownItAnchor, { slugify: githubSlugify });
 
     eleventyConfig.setLibrary("md", markdownItLibrary);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4718,6 +4718,12 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "github-slugger": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
+            "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==",
+            "dev": true
+        },
         "glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "fluid-express": "1.0.18",
         "fluid-lint-all": "1.1.5",
         "fluid-testem": "2.1.15",
+        "github-slugger": "1.4.0",
         "jsdom": "19.0.0",
         "kettle": "2.3.0",
         "node-jqunit": "1.1.9",


### PR DESCRIPTION
Replaces bundled slugify package with github-slugger, which generates slugs for anchors using the same algorithm that GitHub uses. Resolves GH-225.