### PR TITLE
fix: &lt; and &gt; in headers are turned into tags (resolves #231)

### DIFF
--- a/src/documents/IoCReferences.md
+++ b/src/documents/IoCReferences.md
@@ -157,7 +157,7 @@ following the context name in the reference expression are not empty, the framew
 Components which are not in scope for resolution from the reference site (shown as a green pentagon) are shown as blue
 squares.
 
-## Examples of {&lt;componentRef&gt;}
+## Examples of {\&lt;componentRef\&gt;}
 
 In the example below, the IoC reference `{that}` refers to the component in which it is being used.
 
@@ -230,7 +230,7 @@ fluid.defaults("fluid.prefs.enactor.tableOfContents", {
 });
 ```
 
-## Examples of {&lt;componentRef&gt;}.&lt;path to member&gt;
+## Examples of {\&lt;componentRef\&gt;}.\&lt;path to member\&gt;
 
 The example below includes several IoC references. All of them are inside a subcomponent declaration and all include
 `{controllers}`, which in this case is a reference to the parent component. Specifically:
@@ -289,7 +289,7 @@ fluid.defaults("fluid.moduleLayoutHandler", {
 });
 ```
 
-## Examples of {&lt;iocss expression&gt;}
+## Examples of {\&lt;iocss expression\&gt;}
 
 The example below uses an [IoCSS](IoCSS.md) expression `{that > moreText}.options.selectors.images`. The expression
 refers to the `images` selector in the `moreText` subcomponent that is a direct descendent of the current component.


### PR DESCRIPTION
Resolves #231 

- escapes `&lt;` and `&gt;` used in markdown headers.